### PR TITLE
Merge platforms

### DIFF
--- a/pipeline/routing/ppr.py
+++ b/pipeline/routing/ppr.py
@@ -284,8 +284,8 @@ def main():
             for ii in range(i + 1 , len(elements)):
                 
                 if elements[i]["IFOPT"] == elements[ii]["IFOPT"]:
-                    # skip if somehow two entries with the same DHID are in the same stop_area
-                    # this should not happen, but can happen if the DHID (ref:IFOPT) is not correctly entered in OSM
+                    # skip if two entries with the same DHID are in the same stop_area
+                    # this should not happen after the platform merging in the stop_places step of the pipeline
                     print(f"WARNING: Two entries with the same DHID ({elements[i]['IFOPT']})! Ignoring ...")
                     continue
                 

--- a/pipeline/stop_places/sql/stop_places.sql
+++ b/pipeline/stop_places/sql/stop_places.sql
@@ -629,7 +629,7 @@ CREATE OR REPLACE AGGREGATE jsonb_combine(jsonb)
   * Create view that contains all platforms and replaces the splitted platforms with merged ones.
   * This is done by first clustering the platforms by their IFOPT and then merging the geometries and tags.
   * The tags of the elements will be merged.
-  *   If there is a key that has different values in the platforms, the value of the last platform is kept.
+  * If there is a key that has different values in the platforms, the value of the last platform is kept.
   */
 CREATE OR REPLACE VIEW platforms_merged AS (
   SELECT


### PR DESCRIPTION
Adresses issue #8

If there are multiple platforms with the same DHID, they are merged. Only platforms that share the same osm_type are merged. If they do not have the same osm_type there is probably an issue with the tagging in OSM.