### PR TITLE
Fix sporadic Connection aborted PPR backend error

### DIFF
--- a/pipeline/routing/run.sh
+++ b/pipeline/routing/run.sh
@@ -15,9 +15,9 @@ if [ "$RUN_PREPROCESSING" = "y" ] || [ "$RUN_PREPROCESSING" = "Y" ] || [ "$RUN_A
 
     # restart the PPR backend container to reload the new routing graph file
     # before restarting, check if the container is already running
-    if [ "$(docker inspect -f '{{.State.Running}}' osm2vdv462_ppr_backend)" = "running" ]; then
+    if [ "$(docker inspect -f '{{.State.Status}}' osm2vdv462_ppr_backend)" = "running" ]; then
       echo "Restarting PPR backend container ..."
-      docker-compose restart osm2vdv462_ppr_backend
+      docker-compose up -d osm2vdv462_ppr_backend --force-recreate
     else
       docker-compose up -d osm2vdv462_ppr_backend
     fi
@@ -31,7 +31,6 @@ else
 fi
 
 echo "Waiting for PPR container to start ..."
-sleep 10
 
 # perform healthcheck on the PPR container and wait until the routing graph is loaded
 # it is not possible to do this in docker compose, because the container would need a tool like curl or wget to perform the healthcheck

--- a/pipeline/routing/run.sh
+++ b/pipeline/routing/run.sh
@@ -31,6 +31,7 @@ else
 fi
 
 echo "Waiting for PPR container to start ..."
+sleep 10
 
 # perform healthcheck on the PPR container and wait until the routing graph is loaded
 # it is not possible to do this in docker compose, because the container would need a tool like curl or wget to perform the healthcheck

--- a/pipeline/routing/run.sh
+++ b/pipeline/routing/run.sh
@@ -14,13 +14,9 @@ if [ "$RUN_PREPROCESSING" = "y" ] || [ "$RUN_PREPROCESSING" = "Y" ] || [ "$RUN_A
     fi
 
     # restart the PPR backend container to reload the new routing graph file
-    # before restarting, check if the container is already running
-    if [ "$(docker inspect -f '{{.State.Status}}' osm2vdv462_ppr_backend)" = "running" ]; then
-      echo "Restarting PPR backend container ..."
-      docker-compose up -d --force-recreate osm2vdv462_ppr_backend
-    else
-      docker-compose up -d osm2vdv462_ppr_backend
-    fi
+    echo "Restarting PPR backend container ..."
+    docker-compose up -d --force-recreate osm2vdv462_ppr_backend
+
   else
     echo "Error: Cannot run preprocessing without importing an OSM file."
     exit 1
@@ -29,9 +25,6 @@ else
   echo "Skipping preprocessing ..."
   docker-compose up -d osm2vdv462_ppr_backend
 fi
-
-echo "Waiting for PPR container to start ..."
-sleep 10
 
 # perform healthcheck on the PPR container and wait until the routing graph is loaded
 # it is not possible to do this in docker compose, because the container would need a tool like curl or wget to perform the healthcheck

--- a/pipeline/routing/run.sh
+++ b/pipeline/routing/run.sh
@@ -3,10 +3,10 @@ if [ "$RUN_PREPROCESSING" = "y" ] || [ "$RUN_PREPROCESSING" = "Y" ] || [ "$RUN_A
   if [ "$IMPORT_FILE_PATH" != "" ]; then
     docker-compose up osm2vdv462_ppr_preprocess
 
-    exit_status=$(docker inspect osm2vdv462_ppr_preprocess --format='{{.State.ExitCode}}')
+    exit_status=$(docker inspect --format='{{.State.ExitCode}}' osm2vdv462_ppr_preprocess)
 
     # always remove the preprocessing container, even if it exited succesfully
-    docker-compose rm osm2vdv462_ppr_preprocess -f
+    docker-compose rm -f osm2vdv462_ppr_preprocess
 
     if [ ! $exit_status -eq 0 ]; then
       echo "Error: Preprocess exited with status $exit_status."
@@ -17,7 +17,7 @@ if [ "$RUN_PREPROCESSING" = "y" ] || [ "$RUN_PREPROCESSING" = "Y" ] || [ "$RUN_A
     # before restarting, check if the container is already running
     if [ "$(docker inspect -f '{{.State.Status}}' osm2vdv462_ppr_backend)" = "running" ]; then
       echo "Restarting PPR backend container ..."
-      docker-compose up -d osm2vdv462_ppr_backend --force-recreate
+      docker-compose up -d --force-recreate osm2vdv462_ppr_backend
     else
       docker-compose up -d osm2vdv462_ppr_backend
     fi


### PR DESCRIPTION
When converting a file different from the previous run, or sometimes also the same file, there may be a `('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))` error occuring.

The query to get the running status of the ppr_backend container was wrong and also the command to restart this container.